### PR TITLE
Feature: Support unstructured eval output

### DIFF
--- a/eval_template.ipynb
+++ b/eval_template.ipynb
@@ -313,24 +313,17 @@
     "\n",
     "Since you're using a pydantic dataclass to define the output, you shouldn't need to do any additional re-verification of the output. However, if you want to check a JSON to see if it meets the defined output spec, you can call  `validate_eval_output_format_file` or `validate_eval_output_format_str` to check it.  Feel free to break the json and see the test fail. (eg: remove a field like `sae_lens_release_id`).\n",
     "\n",
-    "The JSON schemas files themselves are generated with `evals/generate_json_schemas.py`, which is run as a pre-commit hook. This hook is designed to generate the schema files, but also allow commits to occur even if the generation of the schema files fail. "
+    "The JSON schemas files themselves are generated with `evals/generate_json_schemas.py`, which is run as a pre-commit hook. This hook is designed to generate the schema files, but also allow commits to occur even if the generation of the schema files fail. \n",
+    "\n",
+    "### What if I have unstructured outputs I want to save into the JSON?\n",
+    "Put unstructured outputs into the `eval_result_unstructured`. This allows putting data of any type. However, be aware that since this has no structure, it's less likely to support sorting, filtering, or visualizations using these values. We highly encourage you to use the `eval_result_metrics` or `eval_result_details whenever possible`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/johnnylin/Documents/Projects/SAE_Bench_Template/.venv/lib/python3.11/site-packages/beartype/_util/hint/pep/utilpeptest.py:339: BeartypeDecorHintPep585DeprecationWarning: PEP 484 type hint typing.Type[evals.base_eval_output.BaseEvalOutput] deprecated by PEP 585. This hint is scheduled for removal in the first Python version released after October 5th, 2025. To resolve this, import this hint from \"beartype.typing\" rather than \"typing\". For further commentary and alternatives, see also:\n",
-      "    https://beartype.readthedocs.io/en/latest/api_roar/#pep-585-deprecations\n",
-      "  warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import os\n",
@@ -371,6 +364,11 @@
     "            \"num_split_features\": 1,\n",
     "        },\n",
     "    ],\n",
+    "    \"eval_result_unstructured\": {\n",
+    "        \"pew pew\": \"pew pew\",\n",
+    "        \"bar\": [\"woof\", 1, 3],\n",
+    "        3: 3,\n",
+    "    },\n",
     "    \"sae_bench_commit_hash\": \"57e9be0ac9199dba6b9f87fe92f80532e9aefced\",\n",
     "    \"sae_lens_id\": \"blocks.3.hook_resid_post__trainer_10\",\n",
     "    \"sae_lens_release_id\": \"sae_bench_pythia70m_sweep_standard_ctx128_0712\",\n",

--- a/evals/absorption/eval_output_schema.json
+++ b/evals/absorption/eval_output_schema.json
@@ -194,6 +194,16 @@
       ],
       "description": "The version of SAE Lens that ran the evaluation.",
       "title": "SAE Lens Version"
+    },
+    "eval_result_unstructured": {
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional. Any additional outputs that don't fit into the structured eval_result_metrics or eval_result_details fields. Since these are unstructured, don't expect this to be easily renderable in UIs, or contain any titles or descriptions.",
+      "title": "Unstructured Results"
     }
   },
   "required": [
@@ -204,7 +214,8 @@
     "sae_bench_commit_hash",
     "sae_lens_id",
     "sae_lens_release_id",
-    "sae_lens_version"
+    "sae_lens_version",
+    "eval_result_unstructured"
   ],
   "title": "Feature Absorption Evaluation - First Letter",
   "type": "object"

--- a/evals/base_eval_output.py
+++ b/evals/base_eval_output.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict
 import json
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 from pydantic.dataclasses import dataclass
 from pydantic import Field, field_validator, model_validator
 
@@ -139,7 +139,7 @@ class BaseEvalOutput(
     eval_result_details: list[BaseResultDetailType] = Field(
         None,
         title="Result Details",
-        description="The details of the evaluation. A list of objects that stores nested or more detailed data, such as details about the absorption of each letter. This is optional.",
+        description="Optional. The details of the evaluation. A list of objects that stores nested or more detailed data, such as details about the absorption of each letter.",
     )
 
     sae_bench_commit_hash: str = Field(
@@ -160,6 +160,12 @@ class BaseEvalOutput(
     sae_lens_version: str | None = Field(
         title="SAE Lens Version",
         description="The version of SAE Lens that ran the evaluation.",
+    )
+
+    eval_result_unstructured: Any | None = Field(
+        default_factory=None,
+        title="Unstructured Results",
+        description="Optional. Any additional outputs that don't fit into the structured eval_result_metrics or eval_result_details fields. Since these are unstructured, don't expect this to be easily renderable in UIs, or contain any titles or descriptions.",
     )
 
     def __init__(self, eval_config: BaseEvalConfigType):

--- a/evals/shift_and_tpp/eval_output_schema.json
+++ b/evals/shift_and_tpp/eval_output_schema.json
@@ -788,6 +788,16 @@
       ],
       "description": "The version of SAE Lens that ran the evaluation.",
       "title": "SAE Lens Version"
+    },
+    "eval_result_unstructured": {
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional. Any additional outputs that don't fit into the structured eval_result_metrics or eval_result_details fields. Since these are unstructured, don't expect this to be easily renderable in UIs, or contain any titles or descriptions.",
+      "title": "Unstructured Results"
     }
   },
   "required": [
@@ -798,7 +808,8 @@
     "sae_bench_commit_hash",
     "sae_lens_id",
     "sae_lens_release_id",
-    "sae_lens_version"
+    "sae_lens_version",
+    "eval_result_unstructured"
   ],
   "title": "TPP Evaluation",
   "type": "object"

--- a/evals/sparse_probing/eval_output_schema.json
+++ b/evals/sparse_probing/eval_output_schema.json
@@ -600,6 +600,16 @@
       ],
       "description": "The version of SAE Lens that ran the evaluation.",
       "title": "SAE Lens Version"
+    },
+    "eval_result_unstructured": {
+      "anyOf": [
+        {},
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional. Any additional outputs that don't fit into the structured eval_result_metrics or eval_result_details fields. Since these are unstructured, don't expect this to be easily renderable in UIs, or contain any titles or descriptions.",
+      "title": "Unstructured Results"
     }
   },
   "required": [
@@ -610,7 +620,8 @@
     "sae_bench_commit_hash",
     "sae_lens_id",
     "sae_lens_release_id",
-    "sae_lens_version"
+    "sae_lens_version",
+    "eval_result_unstructured"
   ],
   "title": "Sparse Probing Evaluation",
   "type": "object"


### PR DESCRIPTION
## Motivation
As pointed out by @adamkarvonen, sometimes we want to allow unstructured outputs in evals, for quick tests or some other reason.

## Solution
I've added a `eval_result_unstructured` key which allows for unstructured outputs, and updated the documentation as well.

## Important
Note that you should not expected the unstructured data to be rendered in UI or easily/safely parsable by anyone else. Try to use the `eval_result_metrics` and `eval_result_details` when possible.
