### PR TITLE
set k = 1, 2, 5 default display = true for sparse probing

### DIFF
--- a/evals/sparse_probing/eval_output.py
+++ b/evals/sparse_probing/eval_output.py
@@ -22,16 +22,19 @@ class SparseProbingLlmMetrics(BaseMetrics):
         default=None,
         title="LLM Top 1 Test Accuracy",
         description="LLM top 1 test accuracy",
+        json_schema_extra={"default_display": True},
     )
     llm_top_2_test_accuracy: float | None = Field(
         default=None,
         title="LLM Top 2 Test Accuracy",
         description="LLM top 2 test accuracy",
+        json_schema_extra={"default_display": True},
     )
     llm_top_5_test_accuracy: float | None = Field(
         default=None,
         title="LLM Top 5 Test Accuracy",
         description="LLM top 5 test accuracy",
+        json_schema_extra={"default_display": True},
     )
     llm_top_10_test_accuracy: float | None = Field(
         default=None,
@@ -67,16 +70,19 @@ class SparseProbingSaeMetrics(BaseMetrics):
         default=None,
         title="SAE Top 1 Test Accuracy",
         description="SAE top 1 test accuracy",
+        json_schema_extra={"default_display": True},
     )
     sae_top_2_test_accuracy: float | None = Field(
         default=None,
         title="SAE Top 2 Test Accuracy",
         description="SAE top 2 test accuracy",
+        json_schema_extra={"default_display": True},
     )
     sae_top_5_test_accuracy: float | None = Field(
         default=None,
         title="SAE Top 5 Test Accuracy",
         description="SAE top 5 test accuracy",
+        json_schema_extra={"default_display": True},
     )
     sae_top_10_test_accuracy: float | None = Field(
         default=None,

--- a/evals/sparse_probing/eval_output_schema.json
+++ b/evals/sparse_probing/eval_output_schema.json
@@ -88,6 +88,7 @@
             }
           ],
           "default": null,
+          "default_display": true,
           "description": "LLM top 1 test accuracy",
           "title": "LLM Top 1 Test Accuracy"
         },
@@ -101,6 +102,7 @@
             }
           ],
           "default": null,
+          "default_display": true,
           "description": "LLM top 2 test accuracy",
           "title": "LLM Top 2 Test Accuracy"
         },
@@ -114,6 +116,7 @@
             }
           ],
           "default": null,
+          "default_display": true,
           "description": "LLM top 5 test accuracy",
           "title": "LLM Top 5 Test Accuracy"
         },
@@ -439,6 +442,7 @@
             }
           ],
           "default": null,
+          "default_display": true,
           "description": "SAE top 1 test accuracy",
           "title": "SAE Top 1 Test Accuracy"
         },
@@ -452,6 +456,7 @@
             }
           ],
           "default": null,
+          "default_display": true,
           "description": "SAE top 2 test accuracy",
           "title": "SAE Top 2 Test Accuracy"
         },
@@ -465,6 +470,7 @@
             }
           ],
           "default": null,
+          "default_display": true,
           "description": "SAE top 5 test accuracy",
           "title": "SAE Top 5 Test Accuracy"
         },


### PR DESCRIPTION
As per adam, for sparse probing we should display only 1, 2, and 5 by default.