### PR TITLE
New Core output format, plus converter

### DIFF
--- a/evals/core/convert_directory.py
+++ b/evals/core/convert_directory.py
@@ -1,0 +1,45 @@
+import json
+import sys
+from pathlib import Path
+from evals.core.eval_output import CoreEvalOutput
+from evals.core.main import convert_feature_metrics
+
+# This script is used to convert an old-format eval output to the new format.
+# The old format is no longer produced, so you don't need to use this script.
+
+# load input directory from command line
+input_dir = Path(sys.argv[1])
+
+# Get all JSON files in directory, sorted alphabetically
+input_files = sorted(input_dir.glob("*.json"))
+
+if not input_files:
+    print(f"No JSON files found in {input_dir}")
+    sys.exit(1)
+
+# Create outputs directory if it doesn't exist
+output_dir = input_dir / "converted_outputs"
+output_dir.mkdir(exist_ok=True)
+
+# Convert each file
+for input_file in input_files:
+    print(f"Converting {input_file}")
+    output_file = output_dir / input_file.name
+    with open(input_file, "r") as f:
+        data = json.load(f)
+    feature_metrics = convert_feature_metrics(data["eval_result_details"][0])
+    data["eval_result_details"] = feature_metrics
+    with open(output_file, "w") as f:
+        eval_output = CoreEvalOutput(
+            eval_config=data["eval_config"],
+            eval_id=data["eval_id"],
+            datetime_epoch_millis=data["datetime_epoch_millis"],
+            eval_result_metrics=data["eval_result_metrics"],
+            eval_result_details=data["eval_result_details"],
+            eval_result_unstructured=data.get("eval_result_unstructured", {}),
+            sae_bench_commit_hash=data["sae_bench_commit_hash"],
+            sae_lens_id=data["sae_lens_id"],
+            sae_lens_release_id=data["sae_lens_release_id"],
+            sae_lens_version=data["sae_lens_version"],
+        )
+        eval_output.to_json_file(str(output_file))

--- a/evals/core/eval_config.py
+++ b/evals/core/eval_config.py
@@ -1,11 +1,7 @@
-from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
-import subprocess
-from typing import Optional
 from pydantic.dataclasses import dataclass
 from pydantic import Field
 from evals.base_eval_output import BaseEvalConfig
-from sae_lens import SAEConfig
+
 
 # Define the eval config, which inherits from BaseEvalConfig, and include fields with titles and descriptions.
 @dataclass

--- a/evals/core/eval_output.py
+++ b/evals/core/eval_output.py
@@ -10,6 +10,7 @@ from evals.base_eval_output import (
 
 EVAL_TYPE_ID_CORE = "core"
 
+
 # Define metrics for model behavior preservation
 @dataclass
 class ModelBehaviorPreservationMetrics(BaseMetrics):
@@ -26,6 +27,7 @@ class ModelBehaviorPreservationMetrics(BaseMetrics):
         title="KL Divergence with SAE",
         description="KL divergence when using the SAE reconstruction",
     )
+
 
 # Define metrics for model performance preservation
 @dataclass
@@ -48,6 +50,7 @@ class ModelPerformancePreservationMetrics(BaseMetrics):
         description="Base cross entropy loss without any intervention",
     )
 
+
 # Define metrics for reconstruction quality
 @dataclass
 class ReconstructionQualityMetrics(BaseMetrics):
@@ -64,6 +67,7 @@ class ReconstructionQualityMetrics(BaseMetrics):
         title="Cosine Similarity",
         description="Cosine similarity between original activation and SAE reconstruction",
     )
+
 
 # Define metrics for shrinkage
 @dataclass
@@ -86,6 +90,7 @@ class ShrinkageMetrics(BaseMetrics):
         description="Measure of systematic bias in the reconstruction",
     )
 
+
 # Define metrics for sparsity
 @dataclass
 class SparsityMetrics(BaseMetrics):
@@ -99,6 +104,7 @@ class SparsityMetrics(BaseMetrics):
         description="Average sum of absolute feature activations",
     )
 
+
 # Define metrics for token stats
 @dataclass
 class TokenStatsMetrics(BaseMetrics):
@@ -110,6 +116,7 @@ class TokenStatsMetrics(BaseMetrics):
         title="Total Tokens (Sparsity/Variance)",
         description="Total number of tokens used in sparsity and variance evaluation",
     )
+
 
 # Define the categories themselves
 @dataclass
@@ -139,34 +146,40 @@ class CoreMetricCategories(BaseMetricCategories):
         description="Statistics about the number of tokens used in evaluation",
     )
 
+
 # Define the feature-wise metrics
 @dataclass
-class CoreFeatureMetrics(BaseResultDetail):
-    feature_density: list[float] = Field(
+class CoreFeatureMetric(BaseResultDetail):
+    index: int = Field(
+        title="Feature Index",
+        description="Index of the feature in the SAE",
+    )
+    feature_density: float = Field(
         title="Feature Density",
         description="Proportion of tokens that activate each feature",
     )
-    consistent_activation_heuristic: list[float] = Field(
+    consistent_activation_heuristic: float = Field(
         title="Consistent Activation Heuristic",
         description="Average number of tokens per prompt that activate each feature",
     )
-    encoder_bias: list[float] = Field(
+    encoder_bias: float = Field(
         title="Encoder Bias",
         description="Bias terms in the encoder for each feature",
     )
-    encoder_norm: list[float] = Field(
+    encoder_norm: float = Field(
         title="Encoder Norm",
         description="L2 norm of encoder weights for each feature",
     )
-    encoder_decoder_cosine_sim: list[float] = Field(
+    encoder_decoder_cosine_sim: float = Field(
         title="Encoder-Decoder Cosine Similarity",
         description="Cosine similarity between encoder and decoder weights for each feature",
     )
 
+
 # Define the eval output
 @dataclass(config=ConfigDict(title="Core SAE Evaluation"))
 class CoreEvalOutput(
-    BaseEvalOutput[CoreEvalConfig, CoreMetricCategories, CoreFeatureMetrics]
+    BaseEvalOutput[CoreEvalConfig, CoreMetricCategories, CoreFeatureMetric]
 ):
     """
     The output of core SAE evaluations measuring reconstruction quality, sparsity, and model preservation.
@@ -176,7 +189,7 @@ class CoreEvalOutput(
     eval_id: str
     datetime_epoch_millis: int
     eval_result_metrics: CoreMetricCategories
-    eval_result_details: list[CoreFeatureMetrics] = Field(
+    eval_result_details: list[CoreFeatureMetric] = Field(
         default_factory=list,
         title="Feature-wise Metrics",
         description="Detailed metrics for each feature in the SAE",

--- a/evals/core/eval_output_schema.json
+++ b/evals/core/eval_output_schema.json
@@ -78,57 +78,48 @@
       "title": "CoreEvalConfig",
       "type": "object"
     },
-    "CoreFeatureMetrics": {
+    "CoreFeatureMetric": {
       "properties": {
+        "index": {
+          "description": "Index of the feature in the SAE",
+          "title": "Feature Index",
+          "type": "integer"
+        },
         "feature_density": {
           "description": "Proportion of tokens that activate each feature",
-          "items": {
-            "type": "number"
-          },
           "title": "Feature Density",
-          "type": "array"
+          "type": "number"
         },
         "consistent_activation_heuristic": {
           "description": "Average number of tokens per prompt that activate each feature",
-          "items": {
-            "type": "number"
-          },
           "title": "Consistent Activation Heuristic",
-          "type": "array"
+          "type": "number"
         },
         "encoder_bias": {
           "description": "Bias terms in the encoder for each feature",
-          "items": {
-            "type": "number"
-          },
           "title": "Encoder Bias",
-          "type": "array"
+          "type": "number"
         },
         "encoder_norm": {
           "description": "L2 norm of encoder weights for each feature",
-          "items": {
-            "type": "number"
-          },
           "title": "Encoder Norm",
-          "type": "array"
+          "type": "number"
         },
         "encoder_decoder_cosine_sim": {
           "description": "Cosine similarity between encoder and decoder weights for each feature",
-          "items": {
-            "type": "number"
-          },
           "title": "Encoder-Decoder Cosine Similarity",
-          "type": "array"
+          "type": "number"
         }
       },
       "required": [
+        "index",
         "feature_density",
         "consistent_activation_heuristic",
         "encoder_bias",
         "encoder_norm",
         "encoder_decoder_cosine_sim"
       ],
-      "title": "CoreFeatureMetrics",
+      "title": "CoreFeatureMetric",
       "type": "object"
     },
     "CoreMetricCategories": {
@@ -368,7 +359,7 @@
     "eval_result_details": {
       "description": "Detailed metrics for each feature in the SAE",
       "items": {
-        "$ref": "#/$defs/CoreFeatureMetrics"
+        "$ref": "#/$defs/CoreFeatureMetric"
       },
       "title": "Feature-wise Metrics",
       "type": "array"

--- a/evals/shift_and_tpp/eval_output_schema.json
+++ b/evals/shift_and_tpp/eval_output_schema.json
@@ -23,8 +23,8 @@
           "type": "boolean"
         },
         "early_stopping_patience": {
-          "default": 40,
-          "description": "This reduces randomness in the SCR results.",
+          "default": 20,
+          "description": "We set early stopping patience to probe epochs, so we always train for the same amount.",
           "title": "Early Stopping Patience",
           "type": "integer"
         },
@@ -59,7 +59,7 @@
           "type": "integer"
         },
         "probe_epochs": {
-          "default": 100,
+          "default": 20,
           "description": "Number of epochs to train the linear probe. Many epochs are needed to decrease randomness in the SCR results.",
           "title": "Probe Epochs",
           "type": "integer"
@@ -68,6 +68,12 @@
           "default": 0.001,
           "description": "Probe learning rate.",
           "title": "Probe LR",
+          "type": "number"
+        },
+        "probe_l1_penalty": {
+          "default": 0.001,
+          "description": "L1 sparsity penalty when training the linear probe.",
+          "title": "Probe L1 Penalty",
           "type": "number"
         },
         "sae_batch_size": {


### PR DESCRIPTION
Slight change to core output format.

@curt-tigges to:
1) run an extremely small eval run to get an output json file
2) save that output json file to tests/test_data/core/core_expected_results.json
3) create simple test for it that compares the result to that expected_results json file (eg same as the tests/test_absorption.py)