### PR TITLE
Added option to exclude special tokens from SAE reconstruction

### DIFF
--- a/evals/core/eval_config.py
+++ b/evals/core/eval_config.py
@@ -71,6 +71,11 @@ class CoreEvalConfig(BaseEvalConfig):
         title="Compute Featurewise Weight-Based Metrics",
         description="Compute featurewise weight-based metrics",
     )
+    exclude_special_tokens_from_reconstruction: bool = Field(
+        default=False,
+        title="Exclude Special Tokens from Reconstruction",
+        description="Exclude special tokens like BOS, EOS, PAD from reconstruction",
+    )
     verbose: bool = Field(
         default=False,
         title="Verbose",


### PR DESCRIPTION
This PR adds the ability to exclude special tokens (BOS, EOS, PAD, which are already ignored in some parts of the code) from the SAE reconstruction during Core evaluations.